### PR TITLE
Fix for rails 6.1 to delegate `external_routes`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,30 @@ on: [push,pull_request]
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - ruby-version: 2.7.2
+            rails-version: '~> 5.2.4'
+          - ruby-version: 2.7.2
+            rails-version: '~> 6.0.3'
+          - ruby-version: 2.7.2
+            rails-version: '~> 6.1.0'
+          - ruby-version: 3.0.0
+            rails-version: '~> 6.0.3'
+          - ruby-version: 3.0.0
+            rails-version: '~> 6.1.0'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.0
+        ruby-version: ${{ matrix.ruby-version }}
     - name: Run the default task
       run: |
         gem install bundler -v 2.2.0.rc.2
         bundle install
         bundle exec rake
+      env:
+        RAILS_VERSION: ${{ matrix.rails-version }}

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in routes_lazy_routes.gemspec
 gemspec
 
+gem "rails", ENV["RAILS_VERSION"] if ENV["RAILS_VERSION"]
+
 gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.0"

--- a/lib/routes_lazy_routes/routes_reloader_wrapper.rb
+++ b/lib/routes_lazy_routes/routes_reloader_wrapper.rb
@@ -2,7 +2,7 @@
 
 module RoutesLazyRoutes
   class RoutesReloaderWrapper
-    delegate :paths, :eager_load=, :updated?, :route_sets, to: :@original_routes_reloader
+    delegate :paths, :eager_load=, :updated?, :route_sets, :external_routes, to: :@original_routes_reloader
 
     def initialize(original_routes_reloader)
       @original_routes_reloader = original_routes_reloader


### PR DESCRIPTION
This commit fixes the following error on rails 6.1:
```
$ bundle exec rake
Traceback (most recent call last):
  23: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb:5:in `<main>'
  22: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb:5:in `select'
  21: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb:17:in `block in <main>'
  20: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/rake-13.0.3/lib/rake/rake_test_loader.rb:17:in `require'
  19: from /Users/tricknotes/src/github.com/amatsuda/routes_lazy_routes/test/routes_lazy_routes_test.rb:3:in `<top (required)>'
  18: from /Users/tricknotes/src/github.com/amatsuda/routes_lazy_routes/test/routes_lazy_routes_test.rb:3:in `require'
  17: from /Users/tricknotes/src/github.com/amatsuda/routes_lazy_routes/test/test_helper.rb:22:in `<top (required)>'
  16: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/railtie.rb:207:in `method_missing'
  15: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/railtie.rb:207:in `public_send'
  14: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/application.rb:384:in `initialize!'
  13: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/initializable.rb:60:in `run_initializers'
  12: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
  11: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
  10: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
  9: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `call'
  8: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:347:in `each'
  7: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
  6: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
  5: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
  4: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
  3: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/initializable.rb:61:in `block in run_initializers'
  2: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/initializable.rb:32:in `run'
  1: from /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/initializable.rb:32:in `instance_exec'
  /Users/tricknotes/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/railties-6.1.0/lib/rails/engine.rb:608:in `block in <class:Engine>': undefined method `external_routes' for #<RoutesLazyRoutes::RoutesReloaderWrapper:0x00007ff52221cab8> (NoMethodError)
rake aborted!
Command failed with status (1)
/Users/tricknotes/.rbenv/versions/2.7.2/bin/bundle:23:in `load'
/Users/tricknotes/.rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
```