### PR TITLE
Fix missing task error on Rails 6.1

### DIFF
--- a/lib/routes_lazy_routes/tasks/routes_lazy_routes.rake
+++ b/lib/routes_lazy_routes/tasks/routes_lazy_routes.rake
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-namespace :routes_lazy_routes do
-  task :eager_load do
-    RoutesLazyRoutes.eager_load!
+if Rake::Task.task_defined?('routes')
+  namespace :routes_lazy_routes do
+    task :eager_load do
+      RoutesLazyRoutes.eager_load!
+    end
   end
-end
 
-Rake::Task['routes'].enhance ['routes_lazy_routes:eager_load']
+  Rake::Task['routes'].enhance ['routes_lazy_routes:eager_load']
+end


### PR DESCRIPTION
## Problem

I encountered an error on my application with routes_lazy_routes 0.3.2 and rails 6.1.3.1.

> Don't know how to build task 'routes' (See the list of available tasks with `rails --tasks`)

This is probably due to the removal of  `routes` rake task at rails 6.1 (https://github.com/rails/rails/commit/e152f83c64596e3c701d1b34175ae0fa8669c983).

## Changes

Add `if Rake::Task.task_defined?('routes')` before calling `Rake::Task['routes'].enhance`.