### PR TITLE
Add note for worker process

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ If you're bundling this in the production server, it'd be a good idea to throw a
 
 - And, as already explained, sending a request to the Rails server automatically runs `RoutesLazyRoutes.eager_load!` on the server.
 
+- On the other hand, you need manually calling `RoutesLazyRoutes.eager_load!` inside your worker process (e.g. Sidekiq) to resolve named routes like the following:
+  ``` ruby
+  # config/initializers/sidekiq.rb
+  Sidekiq.configure_server do |config|
+    if defined?(RoutesLazyRoutes)
+      Rails.application.config.after_initialize do
+        RoutesLazyRoutes.eager_load!
+      end
+    end
+  end
+  ```
 
 ## Contributing
 


### PR DESCRIPTION
Without calling `RoutesLazyRoutes.eager_load!`, named routes don't be resolved Inside worker process.
However, I don't have any good idea to resolve this issue in routes_lazy_routes.
So that I added a note for worker process.

----
Here is a screenshot for rendered markdown:
![image](https://user-images.githubusercontent.com/290782/124340195-6e0d5900-dbee-11eb-8894-486f30255ff0.png)
