### PR TITLE
Delegate run_after_load_paths= to original_routes_reloader for Rails 7.0 compatibility

### DIFF
--- a/lib/routes_lazy_routes/routes_reloader_wrapper.rb
+++ b/lib/routes_lazy_routes/routes_reloader_wrapper.rb
@@ -2,7 +2,13 @@
 
 module RoutesLazyRoutes
   class RoutesReloaderWrapper
-    delegate :paths, :eager_load=, :updated?, :route_sets, :external_routes, to: :@original_routes_reloader
+    delegate :paths,
+             :eager_load=,
+             :run_after_load_paths=,
+             :updated?,
+             :route_sets,
+             :external_routes,
+             to: :@original_routes_reloader
 
     def initialize(original_routes_reloader)
       @original_routes_reloader = original_routes_reloader


### PR DESCRIPTION
Currently this awesome gem breaks the boot for applications on Rails `main` branch (essentially Rails 7.0 alpha) with the following error:
```
railties-7.0.0.alpha2/lib/rails/application/finisher.rb:144:in `block in <module:Finisher>': undefined method `run_after_load_paths=' for #<RoutesLazyRoutes::RoutesReloaderWrapper:0x00007f9fb72bdfa0
```

The `run_after_load_paths=` writer was introduced here - https://github.com/rails/rails/commit/ee647d4b0aa83731d5e6361519909970e94010e0#diff-00da4f9d9c3c915539e3449170d79c125ada1f0828c026cecd3927e5444d1d08R12

I have verified the fix on a fresh Rails application with a single `scaffold` controller. I'll try to spend some more time trying it on a real app using Rails 7

However I'm not completely sure how reasonable it is to try to make it work with Rails 7.0 considering that it's an alpha release of Rails 🤔 

Thanks! ❤️ 