### PR TITLE
CI: use bundler-cache: true to install gems

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # 'bundle install' and cache
     - name: Run the default task
-      run: |
-        gem install bundler
-        bundle install
-        bundle exec rake
+      run: bundle exec rake
       env:
         RAILS_VERSION: ${{ matrix.rails-version }}


### PR DESCRIPTION
...and have cache
This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.