### PR TITLE
Eager load routes when a controller test is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you're bundling this in the production server, it'd be a good idea to throw a
 
 - `Rails.application.eager_load!` automatically invokes `RoutesLazyRoutes.eager_load!` since that should be what we expect for `Rails.application.eager_load!`.
 
-- Loading an integration test automatically kicks `RoutesLazyRoutes.eager_load!` since AD::Integration expects the routes to be loaded.
+- Loading an integration test or controller test automatically kicks `RoutesLazyRoutes.eager_load!` since they expect the routes to be loaded.
 
 - And, as already explained, sending a request to the Rails server automatically runs `RoutesLazyRoutes.eager_load!` on the server.
 

--- a/lib/routes_lazy_routes/railtie.rb
+++ b/lib/routes_lazy_routes/railtie.rb
@@ -21,6 +21,10 @@ module RoutesLazyRoutes
       ActiveSupport.on_load :action_dispatch_integration_test, run_once: true do
         RoutesLazyRoutes.eager_load!
       end
+
+      ActiveSupport.on_load :action_controller_test_case, run_once: true do
+        RoutesLazyRoutes.eager_load!
+      end
     end
   end
 end


### PR DESCRIPTION
Like integration tests, controller tests require the routes to work:

https://github.com/rails/rails/blob/v7.1.3/actionpack/lib/action_controller/test_case.rb#L578